### PR TITLE
Remove unwanted \n

### DIFF
--- a/template/nuxt/pages/index.vue
+++ b/template/nuxt/pages/index.vue
@@ -40,7 +40,6 @@ export default {
   @apply min-h-screen flex justify-center items-center text-center mx-auto;
 }
 */
-
 <% } %>.container {
   margin: 0 auto;
   min-height: 100vh;


### PR DESCRIPTION
When running a vanilla NUXT app, prettier complains of the new line at the top of the style.

```
ERROR in ./pages/index.vue
Module Error (from ./node_modules/eslint-loader/index.js):

C:\---\ratest\pages\index.vue
  36:1  error  Delete `⏎`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

i.e.
```
<style>
   *** THIS LINE ***
.container {
  min-height: 100vh;
  display: flex;
  justify-content: center;
  align-items: center;
  text-align: center;
}
```