### PR TITLE
fix(element-ui): missing element-ui build transpile

### DIFF
--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -95,6 +95,8 @@ module.exports = {
         import: ["~assets/style/variables.styl"]
       }
     },
+    <% } %><% if (ui === 'element-ui') { %>
+    transpile: [/^element-ui/],
     <% } %>
     /*
     ** You can extend webpack config here


### PR DESCRIPTION
Like `vuetify`, `element-ui` needs their lib to be transpiled by Nuxt.

`ElementUI` seems to not work at all and throws an error without this fix.