### PR TITLE
Missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "cross-spawn": "^6.0.5",
+    "glob": "^7.1.3",
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",
     "sao": "^0.22.5",


### PR DESCRIPTION
`glob` is imported by `sao.js`, but is not included in the dependencies. It works under `npm` because `npm` flattens the tree, but that is an artifact of `npm`'s current implementation. When installing `create-nuxt-app` with `pnpm` it fails.

In any case, direct dependencies should always be listed!