### PR TITLE
Move commas to after module name

### DIFF
--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -61,14 +61,14 @@ module.exports = {
   */
   modules: [<% if (axios === 'yes') { %>
     // Doc: https://axios.nuxtjs.org/usage
-    '@nuxtjs/axios'<% } %><% if (ui === 'bootstrap') { %>,
+    '@nuxtjs/axios',<% } %><% if (ui === 'bootstrap') { %>
     // Doc: https://bootstrap-vue.js.org/docs/
-    'bootstrap-vue/nuxt'<% } %><% if (ui === 'bulma') { %>,
+    'bootstrap-vue/nuxt',<% } %><% if (ui === 'bulma') { %>
     // Doc:https://github.com/nuxt-community/modules/tree/master/packages/bulma
-    '@nuxtjs/bulma'<% } %><% if (ui === 'buefy') { %>,
+    '@nuxtjs/bulma',<% } %><% if (ui === 'buefy') { %>
     // Doc: https://buefy.github.io/#/documentation
-    'nuxt-buefy'<% } %><% if (pwa === 'yes') { %>,
-    '@nuxtjs/pwa'<% } %>
+    'nuxt-buefy',<% } %><% if (pwa === 'yes') { %>
+    '@nuxtjs/pwa',<% } %>
   ],<% if (axios === 'yes') { %>
   /*
   ** Axios module configuration


### PR DESCRIPTION
When creating an app with the current config, the file ends up like this:

```javascript
modules: [
    , // Linter does not like this...
    'nuxt-buefy',
    '@nuxtjs/pwa'
  ],
```

So this update would change the file to look like this:

```javascript
modules: [
    'nuxt-buefy',
    '@nuxtjs/pwa', // Last trailing comma
  ],
```