### PR TITLE
Instruct people to delete README.md from /static before production deploy

### DIFF
--- a/template/nuxt/static/README.md
+++ b/template/nuxt/static/README.md
@@ -4,6 +4,7 @@
 
 This directory contains your static files.
 Each file inside this directory is mapped to `/`.
+Thus you'd want to delete this README.md before deploying to production.
 
 Example: `/static/robots.txt` is mapped as `/robots.txt`.
 


### PR DESCRIPTION
I realised that `/static/README.md` was deployed to 3 different websites of ours. It's easy overlook the fact, becoming security concern. 

This simple change might help other people stay more secure.