### PR TITLE
fix: require nuxt-edge instead of nuxt

### DIFF
--- a/template/frameworks/feathers/server/middleware/nuxt.js
+++ b/template/frameworks/feathers/server/middleware/nuxt.js
@@ -1,5 +1,5 @@
 const resolve = require('path').resolve
-const { Nuxt, Builder } = require('nuxt')
+const { Nuxt, Builder } = require('nuxt<% if (edge) { %>-edge<% } %>')
 
 // Setup nuxt.js
 let config = {}

--- a/template/server/index-express.js
+++ b/template/server/index-express.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const consola = require('consola')
-const { Nuxt, Builder } = require('nuxt')
+const { Nuxt, Builder } = require('nuxt<% if (edge) { %>-edge<% } %>')
 const app = express()
 
 // Import and Set Nuxt.js options

--- a/template/server/index-koa.js
+++ b/template/server/index-koa.js
@@ -1,6 +1,6 @@
 const Koa = require('koa')
 const consola = require('consola')
-const { Nuxt, Builder } = require('nuxt')
+const { Nuxt, Builder } = require('nuxt<% if (edge) { %>-edge<% } %>')
 
 const app = new Koa()
 

--- a/template/server/index-micro.js
+++ b/template/server/index-micro.js
@@ -1,7 +1,7 @@
 const micro = require('micro')
 const consola = require('consola')
 const dispatch = require('micro-route/dispatch')
-const { Nuxt, Builder } = require('nuxt')
+const { Nuxt, Builder } = require('nuxt<% if (edge) { %>-edge<% } %>')
 
 // Require nuxt config
 const config = require('../nuxt.config.js')


### PR DESCRIPTION
If app is generated with `--edge` flag require `nuxt-edge` instead of `nuxt`. Else console outputs `Error: Cannot find module 'nuxt'`