### PR TITLE
Fix initial value of Express host and port

### DIFF
--- a/template/frameworks/express/server/index.js
+++ b/template/frameworks/express/server/index.js
@@ -11,10 +11,7 @@ async function start() {
   // Init Nuxt.js
   const nuxt = new Nuxt(config)
 
-  const {
-    host = process.env.HOST || '127.0.0.1',
-    port = process.env.PORT || 3000
-  } = nuxt.options.server
+  const { host, port } = nuxt.options.server
 
   // Build only in dev mode
   if (config.dev) {


### PR DESCRIPTION
`nuxt.options.server` overwrites host and port.
Therefore, we deleted the initial value and modified it to a concise
writing style.