### PR TITLE
Remove `--` when using yarn

### DIFF
--- a/saofile.js
+++ b/saofile.js
@@ -220,9 +220,9 @@ module.exports = {
     }
 
     if (this.answers.features.includes('linter')) {
-      const options = ['run', 'lint', '--', '--fix'];
+      const options = ['run', 'lint', '--', '--fix']
       if (this.answers.pm === 'yarn') {
-        options.splice(2, 1);
+        options.splice(2, 1)
       }
       spawn.sync(this.answers.pm, options, {
         cwd: this.outDir,

--- a/saofile.js
+++ b/saofile.js
@@ -220,7 +220,11 @@ module.exports = {
     }
 
     if (this.answers.features.includes('linter')) {
-      spawn.sync(this.answers.pm, ['run', 'lint', '--', '--fix'], {
+      const options = ['run', 'lint', '--', '--fix'];
+      if (this.answers.pm === 'yarn') {
+        options.splice(2, 1);
+      }
+      spawn.sync(this.answers.pm, options, {
         cwd: this.outDir,
         stdio: 'inherit'
       })


### PR DESCRIPTION
Removed `--` to fix the following warnings.

`warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`