### PR TITLE
Swapping section container elements to div elements per W3C spec

### DIFF
--- a/template/frameworks/iview/pages/index.vue
+++ b/template/frameworks/iview/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="container">
+  <div class="container">
     <div>
       <logo />
       <h1 class="title">

--- a/template/nuxt/pages/index.vue
+++ b/template/nuxt/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="container">
+  <div class="container">
     <div>
       <logo />
       <h1 class="title">


### PR DESCRIPTION
I noticed that both index.vue pages were using sections for the main page containers instead of div elements like the W3C spec suggests.

Here is a snippet from the spec:

> The section element is not a generic container element. When an element is needed only for styling purposes or as a convenience for scripting, authors are encouraged to use the div element instead. A general rule is that the section element is appropriate only if the element’s contents would be listed explicitly in the document’s outline. 

[https://www.w3.org/TR/html/sections.html#example-1a704a1d](url)