### PR TITLE
chore: gitignore minor fixes

### DIFF
--- a/template/gitignore
+++ b/template/gitignore
@@ -77,8 +77,12 @@ dist
 # Serverless directories
 .serverless
 
-# IDE
+# IDE / Editor
 .idea
+.editorconfig
 
 # Service worker
 sw.*
+
+# Mac OSX
+.DS_Store


### PR DESCRIPTION
When using create-nuxt-app I've found that many **.DS_Store** files are staged to commit and one **.editorconfig** from Visual Studio Code.

I think that it would save a few seconds of developers life and what's also important, in default Vue template .gitignore file **.DS_Store** is on the top of it.