### PR TITLE
chore: update usage information

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ const generator = path.resolve(__dirname, './')
 const cli = cac('create-nuxt-app')
 
 cli
-  .command('[out-dir]', 'Generate in a custom directory or current directory')
+  .command('[out-dir] [options]', 'Generate in a custom directory or current directory')
   .option('--edge', 'To install `nuxt-edge` instead of `nuxt`')
   .action((outDir = '.') => {
     console.log(chalk`{cyan create-nuxt-app v${version}}`)


### PR DESCRIPTION
Presently, the `usage` information shown as part of the help text lacks reference to `options`.

`Present state`

```md
Usage: create-nuxt-app [out-dir]
```

`Updated To`

```md
Usage: create-nuxt-app [out-dir] [options]
```