### PR TITLE
📘fix(readme): spelling fix

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -19,4 +19,4 @@ $ <%= pmRun %> start
 $ <%= pmRun %> generate
 ```
 
-For detailed explanation on how things work, checkout [Nuxt.js docs](https://nuxtjs.org).
+For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).


### PR DESCRIPTION
Check out is the proper verbiage for this particular sentence.