### PR TITLE
Remove .editorconfig from .gitignore

### DIFF
--- a/template/gitignore
+++ b/template/gitignore
@@ -79,7 +79,6 @@ dist
 
 # IDE / Editor
 .idea
-.editorconfig
 
 # Service worker
 sw.*


### PR DESCRIPTION
According to https://editorconfig.org/: 

> EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs.

I would assume that this file is expected to be commited into source control.