### PR TITLE
Should only ignore root logs directory

### DIFF
--- a/template/gitignore
+++ b/template/gitignore
@@ -1,7 +1,7 @@
 # Created by .ignore support plugin (hsz.mobi)
 ### Node template
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
We don't ignore logs directory If a project has logging api. (like `pages/app/logs/index.vue`)

So I suggest logs directory should ignore only root logs directory.

Thank you!