### PR TITLE
Add `rules` to config to allow "npm run dev" to work out of the box.

### DIFF
--- a/template/_stylelint.config.js
+++ b/template/_stylelint.config.js
@@ -1,4 +1,6 @@
 module.exports = {
-  // add your custom config here
-  // https://stylelint.io/user-guide/configuration
+  rules: {
+    // add your custom config here
+    // https://stylelint.io/user-guide/configuration
+  }
 }


### PR DESCRIPTION
The current implementation prevents `npm run dev` from building the client if stylelint was selected.  Adding this one property enables it to build properly out of the box.