### PR TITLE
fix: stylelint config rules is object

### DIFF
--- a/template/_stylelint.config.js
+++ b/template/_stylelint.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   // add your custom config here
   // https://stylelint.io/user-guide/configuration
-  rules: []
+  rules: {}
 }


### PR DESCRIPTION
Change `rules` to Object from Array

>The rules property is an object whose keys are rule names and values are rule configurations. Each rule configuration fits one of the following formats

https://stylelint.io/user-guide/configuration