### PR TITLE
docs(readme): Fix installation command

### DIFF
--- a/saofile.js
+++ b/saofile.js
@@ -16,6 +16,7 @@ module.exports = {
     const axios = this.answers.features.includes('axios')
     const dotenv = this.answers.features.includes('dotenv')
     const esm = this.answers.server === 'none'
+    const pm = this.answers.pm === 'yarn' ? 'yarn' : 'npm'
     const pmRun = this.answers.pm === 'yarn' ? 'yarn' : 'npm run'
 
     const { cliOptions = {} } = this.sao.opts
@@ -30,6 +31,7 @@ module.exports = {
       axios,
       esm,
       edge,
+      pm,
       pmRun,
       dotenv
     }

--- a/template/README.md
+++ b/template/README.md
@@ -6,7 +6,7 @@
 
 ``` bash
 # install dependencies
-$ <%= pmRun %> install
+$ <%= pm %> install
 
 # serve with hot reload at localhost:3000
 $ <%= pmRun %> dev


### PR DESCRIPTION
Fixed npm installation command.

Expected:

```bash
# install dependencies
$ npm install
```

Actual:

```bash
# install dependencies
$ npm run install
```