### PR TITLE
fix: _stylelint.config.js

### DIFF
--- a/template/_stylelint.config.js
+++ b/template/_stylelint.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   // add your custom config here
   // https://stylelint.io/user-guide/configuration
-  rules: []
+  rules: {
+  }
 }


### PR DESCRIPTION
The stylelint `rules` value needs to be an object, not an array. https://stylelint.io/user-guide/configuration#rules

Split `rules: {}` across lines for cleaner diff views.