### PR TITLE
fix(templates): Vuetify copyright year

### DIFF
--- a/template/frameworks/vuetify/layouts/default.vue
+++ b/template/frameworks/vuetify/layouts/default.vue
@@ -83,7 +83,7 @@
       :fixed="fixed"
       app
     >
-      <span>&copy; 2019</span>
+      <span>&copy; 2020</span>
     </v-footer>
   </v-app>
 </template>

--- a/template/frameworks/vuetify/layouts/default.vue
+++ b/template/frameworks/vuetify/layouts/default.vue
@@ -83,7 +83,7 @@
       :fixed="fixed"
       app
     >
-      <span>&copy; 2020</span>
+      <span>&copy; {{ copyrightYear }}</span>
     </v-footer>
   </v-app>
 </template>
@@ -111,6 +111,7 @@ export default {
       right: true,
       rightDrawer: false,
       title: 'Vuetify.js'
+      copyrightYear: new Date().getFullYear()
     }
   }
 }

--- a/template/frameworks/vuetify/layouts/default.vue
+++ b/template/frameworks/vuetify/layouts/default.vue
@@ -83,7 +83,7 @@
       :fixed="fixed"
       app
     >
-      <span>&copy; {{ copyrightYear }}</span>
+      <span>&copy; {{ new Date().getFullYear() }}</span>
     </v-footer>
   </v-app>
 </template>
@@ -110,8 +110,7 @@ export default {
       miniVariant: false,
       right: true,
       rightDrawer: false,
-      title: 'Vuetify.js',
-      copyrightYear: new Date().getFullYear()
+      title: 'Vuetify.js'
     }
   }
 }

--- a/template/frameworks/vuetify/layouts/default.vue
+++ b/template/frameworks/vuetify/layouts/default.vue
@@ -110,7 +110,7 @@ export default {
       miniVariant: false,
       right: true,
       rightDrawer: false,
-      title: 'Vuetify.js'
+      title: 'Vuetify.js',
       copyrightYear: new Date().getFullYear()
     }
   }


### PR DESCRIPTION
The copyright year is now 2019, should be 2020.