### PR TITLE
Fix footer fixed attribute toggling

### DIFF
--- a/template/frameworks/vuetify/layouts/default.vue
+++ b/template/frameworks/vuetify/layouts/default.vue
@@ -80,7 +80,7 @@
       </v-list>
     </v-navigation-drawer>
     <v-footer
-      :fixed="fixed"
+      :absolute="!fixed"
       app
     >
       <span>&copy; {{ new Date().getFullYear() }}</span>


### PR DESCRIPTION
The app attribute automatically applies `position: fixed` to v-footer, so applying `:fixed="false"` has no effect. `:absolute` must be used instead.
> Note: this prop automatically applies position: fixed to the layout element. You can overwrite this functionality by using the absolute prop
> - [Vuetify docs](https://vuetifyjs.com/en/components/footer/)