### PR TITLE
fix: Log.vue is not a module when chose TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 _*.js
 node_modules
+packages/cna-template/template/nuxt/components/Logo.vue
 packages/cna-template/template/nuxt/pages/index.vue
 packages/cna-template/template/frameworks/iview/pages/index.vue
 packages/cna-template/template/frameworks/jest/jest.config.js

--- a/packages/cna-template/template/nuxt/components/Logo.vue
+++ b/packages/cna-template/template/nuxt/components/Logo.vue
@@ -17,6 +17,15 @@
     </g>
   </svg>
 </template>
+
+<%_ if (typescript) { _%>
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({})
+</script>
+
+<%_ } _%>
 <style>
 .NuxtLogo {
   animation: 1s appear;


### PR DESCRIPTION
I added `<script lang="ts">` block to components/Logo.vue because `File '~~~ Logo.vue' is not a module.` occurs in pages/index.vue when TypeScript is selected in `create-nuxt-app` command.

![スクリーンショット 2020-05-23 11 08 02](https://user-images.githubusercontent.com/379587/82719662-8c184280-9ce7-11ea-98e4-ea4ed5dae2dd.png)
