### PR TITLE
fix: eslint issue with ava

### DIFF
--- a/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
+++ b/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
@@ -24,6 +24,6 @@ test('Route / exits and render HTML', async (t) => {
 })
 
 // Close server and ask nuxt to stop listening to file changes
-test.after('Closing server and nuxt.js', (t) => {
+test.after('Closing server and nuxt.js', () => {
   nuxt.close()
 })


### PR DESCRIPTION
If you use this config:
<img width="831" alt="Screenshot 2020-08-28 at 6 09 19 PM" src="https://user-images.githubusercontent.com/19776877/91562026-1b259e00-e95a-11ea-92a8-31c81f77ca23.png">

You'll get this error:
<img width="838" alt="Screenshot 2020-08-28 at 6 09 02 PM" src="https://user-images.githubusercontent.com/19776877/91562041-24166f80-e95a-11ea-8b95-9b07863941d8.png">


This PR fixes that error ❤️ 
