### PR TITLE
fix: updated layout to be in par with vuetify 2.x

### DIFF
--- a/packages/cna-template/template/frameworks/vuetify/pages/index.vue
+++ b/packages/cna-template/template/frameworks/vuetify/pages/index.vue
@@ -1,14 +1,6 @@
 <template>
-  <v-layout
-    column
-    justify-center
-    align-center
-  >
-    <v-flex
-      xs12
-      sm8
-      md6
-    >
+  <v-row justify="center" align="center">
+    <v-col cols="12" sm="8" md="6">
       <div class="text-center">
         <logo />
         <vuetify-logo />
@@ -80,8 +72,8 @@
           </v-btn>
         </v-card-actions>
       </v-card>
-    </v-flex>
-  </v-layout>
+    </v-col>
+  </v-row>
 </template>
 
 <script>


### PR DESCRIPTION
v-row is a wrapper component for v-col. It utilizes flex properties to control the layout and flow of its inner columns. [...] This is the 2.x replacement for v-layout in 1.x.
v-col is a content holder that must be a direct child of v-row. This is the 2.x replacement for v-flex in 1.x.
https://vuetifyjs.com/fr-FR/components/grids/#usage