### PR TITLE
fix(vuetify): updated layout to be on par with Vuetify 2.x

### DIFF
--- a/packages/cna-template/template/frameworks/vuetify/pages/inspire.vue
+++ b/packages/cna-template/template/frameworks/vuetify/pages/inspire.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-layout>
-    <v-flex class="text-center">
+  <v-row>
+    <v-col class="text-center">
       <img
         src="/v.png"
         alt="Vuetify.js"
@@ -14,6 +14,6 @@
           </small>
         </footer>
       </blockquote>
-    </v-flex>
-  </v-layout>
+    </v-col>
+  </v-row>
 </template>


### PR DESCRIPTION
Just a simple layout update to Vuetify version 2.x. Previously using outdated `v-layout` and `v-flex` (from Vuetify 1.x)