### PR TITLE
docs: add `@latest` hint to npm init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npx create-nuxt-app <my-project>
 Or starting with npm v6.1 you can do:
 
 ```bash
-npm init nuxt-app <my-project>
+npm init nuxt-app@latest <my-project>
 ```
 
 Or with [yarn](https://yarnpkg.com/en/):


### PR DESCRIPTION
I just spend hours trying to figure out the problem with my nuxt installation. I set up new projects using `npm init nuxt-app` to compare configurations. This gave me nuxt 2.0.0 which as of this writing is quite outdated. At first I assumed the template was simply not up to date, but then I learned, that `npm init` will not use the latest version, but simply the currently installed version. This might be consistent with other npm commands, but it most likely also consistently causes problems like mine. Most people will want to use the latest version, so I would like to add that to the command.