### PR TITLE
feat: don't install @nuxtjs/eslint-config and @nuxtjs/eslint-config-typescript together

### DIFF
--- a/packages/cna-template/template/nuxt/package.js
+++ b/packages/cna-template/template/nuxt/package.js
@@ -85,6 +85,9 @@ module.exports = {
     if (!typescript || !eslint) {
       delete pkg.devDependencies['@nuxtjs/eslint-config-typescript']
     }
+    if (typescript && eslint) {
+      delete pkg.devDependencies['@nuxtjs/eslint-config']
+    }
     if (typescript) {
       for (const key of Object.keys(scripts)) {
         scripts[key] = scripts[key].replace(/^nuxt( |$)/, 'nuxt-ts$1')


### PR DESCRIPTION
Just a minor optimization of the generated package.json. The documentation of nuxt-ts [states](https://typescript.nuxtjs.org/guide/lint.html#configuration): 

> If you're already using `@nuxtjs/eslint-config`, remove it from your dependencies, the Nuxt TypeScript ESLint config includes it.