### PR TITLE
chore(cna-template): fix link to bulma

### DIFF
--- a/packages/cna-template/template/nuxt/nuxt.config.js
+++ b/packages/cna-template/template/nuxt/nuxt.config.js
@@ -97,7 +97,7 @@
     // https://go.nuxtjs.dev/bootstrap
     'bootstrap-vue/nuxt',
     <%_ } else if (ui === 'bulma') { _%>
-    // https://go.nuxtjs.dev/bootstrap
+    // https://bulma.io
     '@nuxtjs/bulma',
     <%_ } else if (ui === 'buefy') { _%>
     // https://go.nuxtjs.dev/buefy


### PR DESCRIPTION
## Description
Worked with nuxt for the first time today and found this slight issue. After selecting `bulma` as my css framework of choice, it was weird as to why the external link provided lead to bootstrap-vue.

I made this PR to switch the link to the appropriate channel.

PS - there doesn't seem to be a `https://go.nuxtjs.dev/bulma` link so I just used the main bulma website instead. Feel free to change the link if you see fit 🙂

Cheers