### PR TITLE
fix: added dir: 'ltr' to nuxt.config.js

### DIFF
--- a/packages/cna-template/template/nuxt/nuxt.config.js
+++ b/packages/cna-template/template/nuxt/nuxt.config.js
@@ -16,11 +16,12 @@
     titleTemplate: '%s - <%= name %>',
     <%_ } _%>
     title: '<%= name %>',
-    <%_ if (!pwa) { _%>
-    htmlAttrs, {
+    htmlAttrs: {
+      dir: 'ltr',
+      <%_ if (!pwa) { _%>
       lang: 'en'
+      <%_ } _%>
     },
-    <%_ } _%>
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },


### PR DESCRIPTION
Nuxt omits `text-align: end;` and `text-align: start;` CSS rules if `dir` attribute is not set. Some frameworks, like Vuetify, use `start` and `end` by default, as these are needed for RTL support.

Details in this [issue.](https://github.com/nuxt/nuxt.js/issues/4555)

This PR adds a default `dir: 'ltr'` setting, solving this issue.