### PR TITLE
fix: e2e tests are configured with project's nuxt.config

### DIFF
--- a/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
+++ b/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
@@ -1,6 +1,7 @@
 import { resolve } from 'path'
 import test from 'ava'
 import { Nuxt, Builder } from 'nuxt'
+import config from '../../nuxt.config'
 
 // We keep the nuxt and server instance
 // So we can close them at the end of the test
@@ -8,11 +9,12 @@ let nuxt = null
 
 // Init Nuxt.js and create a server listening on localhost:4000
 test.before(async () => {
-  const config = {
+  nuxt = new Nuxt({
+    ...config,
     dev: false,
-    rootDir: resolve(__dirname, '../../')
-  }
-  nuxt = new Nuxt(config)
+    rootDir: resolve(__dirname, '../../'),
+  })
+  await new Builder(nuxt).build()
   await new Builder(nuxt).build()
   await nuxt.server.listen(4000, 'localhost')
 }, 30000)

--- a/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
+++ b/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
@@ -15,7 +15,6 @@ test.before(async () => {
     rootDir: resolve(__dirname, '../../'),
   })
   await new Builder(nuxt).build()
-  await new Builder(nuxt).build()
   await nuxt.server.listen(4000, 'localhost')
 }, 30000)
 

--- a/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
+++ b/packages/cna-template/template/frameworks/ava/test/e2e/index.spec.js
@@ -12,7 +12,7 @@ test.before(async () => {
   nuxt = new Nuxt({
     ...config,
     dev: false,
-    rootDir: resolve(__dirname, '../../'),
+    rootDir: resolve(__dirname, '../../')
   })
   await new Builder(nuxt).build()
   await nuxt.server.listen(4000, 'localhost')


### PR DESCRIPTION
End to end tests should be as close to the real thing as possible, re-creating a whole separate Nuxt configuration from scratch adds potential for inconsistencies.

## Context
Being new to Nuxt I was bashing my head against why Nuxt e2e tests didn't have `$axios` configured, and why my project would fail to evaluate the components I referenced in layout files.
I also noticed that global css didn't work.
All of this because the `nuxt.config.js` wasn't being referenced in the end to end tests. 