### PR TITLE
feat: add nuxt content support for typescript

### DIFF
--- a/packages/cna-template/template/tsconfig.json
+++ b/packages/cna-template/template/tsconfig.json
@@ -25,7 +25,12 @@
     },
     "types": [
       "@types/node",
+<%_ if (content) { _%>
+      "@nuxt/types",
+      "@nuxt/content"
+<%_ } else { _%>
       "@nuxt/types"
+<%_ } _%>
     ]
   },
   "exclude": [

--- a/packages/cna-template/template/tsconfig.json
+++ b/packages/cna-template/template/tsconfig.json
@@ -25,12 +25,12 @@
     },
     "types": [
       "@types/node",
-<%_ if (content) { _%>
+      <%_ if (content) { _%>
       "@nuxt/types",
       "@nuxt/content"
-<%_ } else { _%>
+      <%_ } else { _%>
       "@nuxt/types"
-<%_ } _%>
+      <%_ } _%>
     ]
   },
   "exclude": [

--- a/packages/cna-template/template/tsconfig.json
+++ b/packages/cna-template/template/tsconfig.json
@@ -24,13 +24,11 @@
       ]
     },
     "types": [
-      "@types/node",
-      <%_ if (content) { _%>
       "@nuxt/types",
-      "@nuxt/content"
-      <%_ } else { _%>
-      "@nuxt/types"
+      <%_ if (content) { _%>
+      "@nuxt/content",
       <%_ } _%>
+      "@types/node"
     ]
   },
   "exclude": [


### PR DESCRIPTION
When creating a project with typescript and nuxt content, the types are missing so using `this.$content(...)` throws type errors.

This fixes it by adding `@nuxt/content` types to tsconfig.json as described here https://content.nuxtjs.org/installation/#typescript