### PR TITLE
fix(types): include @nuxtjs/axios types

### DIFF
--- a/packages/cna-template/template/tsconfig.json
+++ b/packages/cna-template/template/tsconfig.json
@@ -25,6 +25,9 @@
     },
     "types": [
       "@nuxt/types",
+      <%_ if (axios) { _%>
+      "@nuxtjs/axios",
+      <%_ } _%>
       <%_ if (content) { _%>
       "@nuxt/content",
       <%_ } _%>


### PR DESCRIPTION
Fix https://github.com/nuxt/create-nuxt-app/issues/690

Include [@nuxtjs/axios types](https://github.com/nuxt-community/axios-module/tree/master/types) into ts compilation.