### PR TITLE
fix: Oruga packagePatterns in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
       "groupName": "webdriverio packages"
     },
     {
-      "packagePatterns": ["@oruga-ui", "oruga"],
+      "packagePatterns": ["@oruga-ui"],
       "groupName": "oruga packages"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
       "groupName": "webdriverio packages"
     },
     {
-      "packagePatterns": ["oruga"],
+      "packagePatterns": ["@oruga-ui", "oruga"],
       "groupName": "oruga packages"
     },
     {


### PR DESCRIPTION
This PR fixes Oruga configuration for renovate.json. I tested it running renovate locally on another repository with the right configuration, I don't know if there's a better way to test renovate.json configuration without creating pull requests.