### PR TITLE
fix(cli): rephrase not empty directory error message

### DIFF
--- a/packages/create-nuxt-app/lib/cli.js
+++ b/packages/create-nuxt-app/lib/cli.js
@@ -34,12 +34,15 @@ cli
     if (cliOptions.info) {
       return showEnvInfo()
     }
-    const files = fs.existsSync(outDir) ? fs.readdirSync(outDir) : []
     console.log()
     console.log(chalk`{cyan create-nuxt-app v${version}}`)
-    if (files.length) {
-      return console.log(chalk.red(`Can't create ${outDir} because there's already a non-empty directory ${outDir} existing in path.`))
+
+    if (fs.existsSync(outDir) && fs.readdirSync(outDir).length) {
+      const baseDir = outDir === '.' ? path.basename(process.cwd()) : outDir
+      return console.error(chalk.red(
+        `Could not create project in ${chalk.bold(baseDir)} because the directory is not empty.`))
     }
+
     console.log(chalk`✨  Generating Nuxt.js project in {cyan ${outDir}}`)
 
     const { verbose, answers } = cliOptions


### PR DESCRIPTION
The user is greeted with the following message if he/she attempts to create a project in the current directory that is non-empty:-

```sh
Can't create . because there's already a non-empty directory . existing in path.
```

This PR aims at rephrasing the above message such that the directory name shows up instead.