### PR TITLE
feat(cli): add user-friendly exit for unknown options

### DIFF
--- a/packages/create-nuxt-app/lib/cli.js
+++ b/packages/create-nuxt-app/lib/cli.js
@@ -24,41 +24,60 @@ const showEnvInfo = async () => {
   process.exit(1)
 }
 
-cli
-  .command('[out-dir]', 'Generate in a custom directory or current directory')
-  .option('-e, --edge', 'To install `nuxt-edge` instead of `nuxt`')
-  .option('-i, --info', 'Print out debugging information relating to the local environment')
-  .option('--answers <json>', 'Skip all the prompts and use the provided answers')
-  .option('--verbose', 'Show debug logs')
-  .option('--overwrite-dir', 'Overwrite the target directory')
-  .action((outDir = '.', cliOptions) => {
-    if (cliOptions.info) {
-      return showEnvInfo()
-    }
-    console.log()
-    console.log(chalk`{cyan create-nuxt-app v${version}}`)
+const run = () => {
+  cli
+    .command('[out-dir]', 'Generate in a custom directory or current directory')
+    .option('-e, --edge', 'To install `nuxt-edge` instead of `nuxt`')
+    .option('-i, --info', 'Print out debugging information relating to the local environment')
+    .option('--answers <json>', 'Skip all the prompts and use the provided answers')
+    .option('--verbose', 'Show debug logs')
+    .option('--overwrite-dir', 'Overwrite the target directory')
+    .action((outDir = '.', cliOptions) => {
+      if (cliOptions.info) {
+        return showEnvInfo()
+      }
+      console.log()
+      console.log(chalk`{cyan create-nuxt-app v${version}}`)
 
-    const { answers, overwriteDir, verbose } = cliOptions
-    if (fs.existsSync(outDir) && fs.readdirSync(outDir).length && !overwriteDir) {
-      const baseDir = outDir === '.' ? path.basename(process.cwd()) : outDir
-      return console.error(chalk.red(
-        `Could not create project in ${chalk.bold(baseDir)} because the directory is not empty.`))
-    }
+      const { answers, overwriteDir, verbose } = cliOptions
+      if (fs.existsSync(outDir) && fs.readdirSync(outDir).length && !overwriteDir) {
+        const baseDir = outDir === '.' ? path.basename(process.cwd()) : outDir
+        return console.error(chalk.red(
+          `Could not create project in ${chalk.bold(baseDir)} because the directory is not empty.`))
+      }
 
-    console.log(chalk`✨  Generating Nuxt.js project in {cyan ${outDir}}`)
+      console.log(chalk`✨  Generating Nuxt.js project in {cyan ${outDir}}`)
 
-    const logLevel = verbose ? 4 : 2
-    // See https://sao.vercel.app/api.html#standalone-cli
-    sao({ generator, outDir, logLevel, answers, cliOptions })
-      .run()
-      .catch((err) => {
-        console.trace(err)
-        process.exit(1)
-      })
-  })
+      const logLevel = verbose ? 4 : 2
+      // See https://sao.vercel.app/api.html#standalone-cli
+      sao({ generator, outDir, logLevel, answers, cliOptions })
+        .run()
+        .catch((err) => {
+          console.trace(err)
+          process.exit(1)
+        })
+    })
 
-cli.help()
+  cli.help()
 
-cli.version(version)
+  cli.version(version)
 
-cli.parse()
+  cli.parse()
+}
+
+try {
+  run()
+} catch (err) {
+  // https://github.com/cacjs/cac/blob/f51fc2254d7ea30b4faea76f69f52fe291811e4f/src/utils.ts#L152
+  // https://github.com/cacjs/cac/blob/f51fc2254d7ea30b4faea76f69f52fe291811e4f/src/Command.ts#L258
+  if (err.name === 'CACError' && err.message.startsWith('Unknown option')) {
+    console.error()
+    console.error(chalk.red(err.message))
+    console.error()
+    cli.outputHelp()
+  } else {
+    console.error()
+    console.error(err)
+  }
+  process.exit(1)
+}


### PR DESCRIPTION
This PR has no related issues.

I added a logic for CNA to show help message instead of raw error stack in case a user (like me 1 hour ago) passes unknown options.
By doing so, the user can find what he/she really wanted and copy it quickly, without running `help` command or seeing documentation.

---

**Explanation of work**

I felt the try-catch block long so I extracted the main part in `run` function.
If you prefer inlined version as before, let me know.

**How I tested**

1. Ran `node lib/cli.js test --unknown-options`, and checked the output (for what I added)
2. Ran `node lib/cli.js test` with `throw new Error('Custom Message')` added before `run` function call, and checked the output (for backward compatibility)
3. Ran `node lib/cli.js test`, and checked the output (for backward compatibility, it shows "not empty" error with exit code 0)