### PR TITLE
chore: add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a bug report to help us improve the tool.
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+<!-- **IMPORTANT!**
+Before reporting a bug, please make sure that you have read through our documentation and you think your problem is indeed an issue related to our tool. -->
+
+### Version
+create-nuxt-app: <!-- ex: v1.0.0 -->
+
+### Steps to reproduce
+
+
+### What is Expected?
+
+
+### What is actually happening?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Nuxt Community Discord
+    url: https://discord.nuxtjs.org/
+    about: Consider asking questions about the module here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for the tool.
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+### Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: Question
+about: Ask a question about the tool.
+title: ''
+labels: 'question'
+assignees: ''
+
+---
+
+<!-- **IMPORTANT!**
+Please make sure to look for an answer to your question in our documentation and the documentation before asking a question here.
+
+If you have a general question regarding the module use Discord `nuxt` channel. Thanks!
+
+Nuxt Discord: https://discord.nuxtjs.org/
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--- Provide a general summary of your changes in the title above -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (a non-breaking change which fixes an issue)
+- [ ] New feature (a non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+
+## Description
+<!--- Describe your changes in detail -->
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
+
+
+## Checklist:
+<!--- Put an `x` in all the boxes that apply. -->
+<!--- If your change requires a documentation PR, please link it appropriately -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes (if not applicable, please state why)


### PR DESCRIPTION
After personal "triage" (reading through issues to find ones that I can help), I found:

- There are some issues that have already fixed while it's still open
- There are issues with no description

This PR is to improve such situation by introducing GitHub Issues templates and PR template.
The contents are copied from Nuxt Content module, with some modification.
