### PR TITLE
stylelint versions

### DIFF
--- a/packages/cna-template/template/_stylelint.config.js
+++ b/packages/cna-template/template/_stylelint.config.js
@@ -2,10 +2,7 @@ module.exports = {
   customSyntax: 'postcss-html',
   extends: [
     'stylelint-config-standard',
-    'stylelint-config-recommended-vue',
-    <%_ if (prettier) { _%>
-    'stylelint-config-prettier'
-    <%_ } _%>
+    'stylelint-config-recommended-vue'
   ],
   // add your custom config here
   // https://stylelint.io/user-guide/configuration

--- a/packages/cna-template/template/nuxt/package.json
+++ b/packages/cna-template/template/nuxt/package.json
@@ -42,9 +42,8 @@
     "lint-staged": "^13.0.3",
     "postcss-html": "^1.5.0",
     "prettier": "^2.7.1",
-    "stylelint": "^14.13.0",
-    "stylelint-config-prettier": "^9.0.3",
+    "stylelint": "^15.6.2",
     "stylelint-config-recommended-vue": "^1.4.0",
-    "stylelint-config-standard": "^28.0.0"
+    "stylelint-config-standard": "^33.0.0"
   }
 }


### PR DESCRIPTION
According to issue #1028 
Updated Stylelint vetsion and its config packages. also, removed `stylelint-config-prettier` since it is no longer needed

## Types of changes
- [x] Bug fix updated stylelint versions
- [x] Bug fix remvoed `stylelint-config-prettier` (deprecated)
